### PR TITLE
Fix Bixby launcher on Samsung devices

### DIFF
--- a/app/src/main/java/com/wstxda/switchai/assistant/BixbyAssistant.kt
+++ b/app/src/main/java/com/wstxda/switchai/assistant/BixbyAssistant.kt
@@ -21,6 +21,6 @@ class BixbyAssistant : AssistantActivity() {
     private fun createBixbyIntent() = createAssistantIntent(
         packageName = Companion.packageName,
         defaultActivity = "com.samsung.android.bixby.assistanthome.deeplink.DeepLinkPublicActivity",
-        voiceInputActivity = "com.samsung.android.bixby.assistanthome.AssistantHomeMainActivity"
+        voiceInputActivity = "com.samsung.android.bixby.assistanthome.AssistantHomeLauncherActivity"
     )
 }


### PR DESCRIPTION
I only changed the `voiceInputActivity` string. That seemed to work for me with SwitchAI in debugging / testing. I'm not sure what `defaultActivity` is for, and may also need to be changed based on your feedback / explanation. It didn't seem to affect anything in my tests. Also, voice activation for Bixby on my Samsung device works automatically independent of SwitchAI.

Happy to update with videos or screenshots if needed.